### PR TITLE
Fixed bug in handling of non-orthogonal unit cells in replicatemol()

### DIFF
--- a/topoutils.tcl
+++ b/topoutils.tcl
@@ -350,7 +350,7 @@ proc ::TopoTools::replicatemol {mol nx ny nz} {
         set bx [expr [lindex $box 1] * cos($gammarad) ]
         set by [expr [lindex $box 1] * sin($gammarad) ]
         set cx [expr [lindex $box 2] * cos($betarad)  ]
-        set cy [expr [lindex $box 2] * [ expr cos($betarad) -cos($betarad) * cos($gammarad)] / sin($gammarad)]
+        set cy [expr [lindex $box 2] * [ expr cos($alpharad) -cos($betarad) * cos($gammarad)] / sin($gammarad)]
         # calc cz
         set V1  [expr [lindex $box 0] *  [lindex $box 1] * [lindex $box 2] ]
         set V21  [expr 1 - cos($alpharad)*cos($alpharad) \


### PR DESCRIPTION
I believe there's a bug in how TopoTools handles non-orthogonal unit cells in the replicatemol() function. If you load the attached pdb file, run "replicatemol 1 1 2", and look at the result, you'll see two atoms that are only 0.828 Angstroms away from each other across the unit cell boundary. If I take the same pdb file and replicate it in Mercury, this does not occur.

[bug-illustration.pdb.txt](https://github.com/akohlmey/topotools/files/1061431/bug-illustration.pdb.txt)

I believe I've traced the bug to this little typo. If you look at http://lammps.sandia.gov/doc/Section_howto.html#howto-12, it says that c_y=(B\dotC-b_x*c_x)/b_y. The dot product of B and C is B*C*cos(alpha), not B*C*cos(beta).

I tested the change in my local distribution, and the atoms no longer overlap.