### PR TITLE
Sort fragments and enable strange atomtypes.

### DIFF
--- a/topogromacs.tcl
+++ b/topogromacs.tcl
@@ -74,6 +74,30 @@ proc ::TopoTools::writegmxtop {filename mol sel {flags none}} {
         }
         $sel set segname $savesegname
         $sel set chain $savechain
+        #Fragments can also be discontinuous, which while not a problem for TopoGromacs, it WILL result in a geometry
+        #the user doesn't expect during simulation. So we check to make sure that fragment numbers are only increasing.
+        set fraglist [$sel get fragment]
+        set lowfrags [lrange $fraglist 0 end-1]
+        set highfrags [lrange $fraglist 1 end]
+        if { [lindex [lsort -real -increasing [vecsub $highfrags $lowfrags]] 0] < -0.5 } {
+            vmdcon -err "writegmxtop: fragments are non-contiguous"
+            vmdcon -info "Grompp reads input coordinates in order, and maps these directly onto atoms as"
+            vmdcon -info "they are listed in the .top file. We have detected fragments out of numerical order"
+            vmdcon -info "in the molecule, which will likely result in a misinterpretation of the input structure."
+            vmdcon -info "Please try the following to generate a reordered structure, and use that as input:"
+            vmdcon -info "set fragsellist \[list\]"
+            vmdcon -info "set bigsel \[atomselect top \"not (water or ions)\"\]"
+            vmdcon -info "foreach frag \[lsort -unique \[\$bigsel get fragment\]\] \{"
+            vmdcon -info "  set fsel \[atomselect top \"fragment \$frag\"\]"
+            vmdcon -info "  lappend fragsellist \$fsel"
+            vmdcon -info "\}"
+            vmdcon -info "set othersel \[atomselect top \"(water or ions)\"\]"
+            vmdcon -info "lappend fragsellist \$othersel"
+            vmdcon -info "set newmol \[::TopoTools::selections2mol \$fragsellist\]"
+            vmdcon -info "animate write psf reordered.psf \$newmol"
+            vmdcon -info "animate write pdb reordered.pdb \$newmol"
+            return -1
+        }
         set typechecklist [$sel get type]
         if { [$sel get name] == $typechecklist } {
             vmdcon -err "writegmxtop: atomnames are identical to atomtypes"
@@ -630,7 +654,7 @@ proc ::TopoTools::writecharmmparams {fp mol sel filelist} {
     #lookup what the masses should be based on what exists in the current molecule.
     foreach type $types {
         if { ! [dict exists $mass $type]} {
-            set subset [atomselect $mol "type $type"]
+            set subset [atomselect $mol "type \"$type\""]
             dict set mass $type [lindex [$subset get mass] 0]
             $subset delete
         }

--- a/topoimpropers.tcl
+++ b/topoimpropers.tcl
@@ -195,8 +195,8 @@ proc ::TopoTools::guessimpropers {sel {flags {}}} {
                     set t1 $b1typ; set b1typ $b2typ; set b2typ $t1
                     set t2 $b1; set b1 $b2; set b2 $t2
                 }
-                set type [join [list $b1typ $b2typ $atyp $b3typ] "-"]
-                lappend newimproperlist [list $type $b1 $b2 $aidx $b3]
+                set type [join [list $atyp $b1typ $b2typ $b3typ] "-"]
+                lappend newimproperlist [list $type $aidx $b1 $b2 $b3]
             }
         }
     }


### PR DESCRIPTION
Based on the experience from a topotools user today, I think we need to make two adjustments before the next release of VMD. The first is to detect out-of-order molecular fragments, which will cause problems for grompp when the coordinates are read sequentially but the individual molecules are out of order. The second is a small change to the "type" selection we make. This needs to be protected so that special characters don't break the parser.