### PR TITLE
Add fake cmaptypes when needed

### DIFF
--- a/topogromacs.tcl
+++ b/topogromacs.tcl
@@ -147,7 +147,7 @@ proc ::TopoTools::writegmxtop {filename mol sel {flags none}} {
         ; # puts $fp "\n\[ constrainttypes \]\n;"
         puts $fp "\n\[ angletypes \]\n; i j k func th0 cth\n  C C C 1 109.500 100.0 ; totally bogus"
         puts $fp "\n\[ dihedraltypes \]\n; i j k l func coefficients\n  C C C C 1 0.0 3 10.0 ; totally bogus"
-        puts $fp "\n\[ cmaptypes \]\n; i j k l m func\n C C C C C 1 0.0 0.0 ; totally bogus"
+        puts $fp "\n\[ cmaptypes \]\n; i j k l m func\n C C C C C 1 1 1 0; totally bogus"
     } else {
         vmdcon -info "Generating a real gromacs topology file: $filename"
         puts $fp "; This gromacs topology generated using topotools, and contains parameter"

--- a/topogromacs.tcl
+++ b/topogromacs.tcl
@@ -147,6 +147,7 @@ proc ::TopoTools::writegmxtop {filename mol sel {flags none}} {
         ; # puts $fp "\n\[ constrainttypes \]\n;"
         puts $fp "\n\[ angletypes \]\n; i j k func th0 cth\n  C C C 1 109.500 100.0 ; totally bogus"
         puts $fp "\n\[ dihedraltypes \]\n; i j k l func coefficients\n  C C C C 1 0.0 3 10.0 ; totally bogus"
+        puts $fp "\n\[ cmaptypes \]\n; i j k l m func\n C C C C C 1 0.0 0.0 ; totally bogus"
     } else {
         vmdcon -info "Generating a real gromacs topology file: $filename"
         puts $fp "; This gromacs topology generated using topotools, and contains parameter"


### PR DESCRIPTION
Based on today's VMD-L topic, it looks like we had an oversight for when there are crossterms in the structure loaded into VMD. No crossterm parameters are written, so grompp chokes when it can't reconcile parameters with terms.